### PR TITLE
fix raised-linked toolbar button borders

### DIFF
--- a/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
@@ -1734,8 +1734,8 @@ GtkTextView {
 .inline-toolbar.toolbar GtkToolButton .button:focus,
 .inline-toolbar.toolbar GtkToolButton .button:focus:active,
 .inline-toolbar.toolbar GtkToolButton .button:insensitive {
-    border-right-width: 0;
-    border-left-width: 1px;
+    border-right-width: 1px;
+    border-left-width: 0;
     border-radius: 0;
 }
 


### PR DESCRIPTION
After installing Rhythmbox3 found this issue with raised linked toolbar buttons:
![linked_button_issue](https://f.cloud.github.com/assets/2231759/1376163/02b0a1ce-3a90-11e3-92d9-4d34c944d8dd.png)

This pull request fixes the problem:
![fixed_borders](https://f.cloud.github.com/assets/2231759/1376187/52042b88-3a90-11e3-91a3-1d8ddd123d93.png)

This is my first pull request so hopefully it is done properly.
