### PR TITLE
GTK2-style buttons for GTK3

### DIFF
--- a/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
@@ -98,7 +98,7 @@ GtkWindow {
 
 *:selected,
 *:selected:focus {
-    background-color: alpha(@theme_selected_bg_color, 0.9);
+    background-color: @theme_selected_bg_color;
     color: @theme_selected_fg_color;
 }
 
@@ -236,94 +236,82 @@ GtkAssistant .sidebar {
  * button *
  **********/
 .button {
-    -GtkWidget-focus-padding: 1;
+    -GtkWidget-focus-padding: 0;
     -GtkWidget-focus-line-width: 0;
 
-    padding: 2px;
+	padding: 4px 14px;
+}
+
+GtkComboBox .button {
+	padding: 2px 2px;
 }
 
 GtkSwitch.slider,
 .button {
     background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(shade(@theme_bg_color, 1.02), 1.05)),
-                                     to (shade(shade(@theme_bg_color, 1.02), 0.97)));
+                                     from (shade(shade(@theme_bg_color, 1.13), 1.3)),
+                                     to (shade(shade(@theme_bg_color, 1.13), 0.92)));
 
     border-radius: 3px;
-    border-top-color: shade(@theme_bg_color, 0.8);
-    border-right-color: shade(@theme_bg_color, 0.72);
-    border-bottom-color: shade(@theme_bg_color, 0.7);
-    border-left-color: shade(@theme_bg_color, 0.72);
     border-style: solid;
+    border-color: shade(@theme_bg_color, 0.65);
     color: @theme_fg_color;
 }
 
 .button:active {
     background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(shade(@theme_bg_color, 0.85), 1.05)),
-                                     to (shade(shade(@theme_bg_color, 0.85), 0.97)));
+                                     from (shade(shade(@theme_bg_color, 0.8), 1.3)),
+                                     to (shade(shade(@theme_bg_color, 0.8), 0.92)));
 
-    border-color: shade(@theme_bg_color, 0.6);
+    border-color: shade(@theme_bg_color, 0.65);
 }
 
 .button:hover,
 .button:active:hover {
     background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(@theme_bg_color, 1.15)),
-                                     to (shade(@theme_bg_color, 1.07)));
-
-    border-top-color: shade(@theme_bg_color, 0.85);
-    border-right-color: shade(@theme_bg_color, 0.78);
-    border-bottom-color: shade(@theme_bg_color, 0.7);
-    border-left-color: shade(@theme_bg_color, 0.78);
+        from (shade(mix(@theme_focus_color, @theme_bg_color, 0.96), 1.3)),
+        to (shade(mix(@theme_focus_color, @theme_bg_color, 0.96), 0.92)));
 }
 
 .button:focus,
 .button:hover:focus,
-.button:active:focus {
-    border-color: shade(@theme_selected_bg_color, 0.8);
+.button:active:focus {   
+    background-image: -gtk-gradient(linear, left top, left bottom,
+        from (shade(mix(@theme_focus_color, @theme_bg_color, 0.7), 1.3)),
+        to (shade(mix(@theme_focus_color, @theme_bg_color, 0.7), 0.92)));
+    border-color: @theme_selected_bg_color;
 }
 
 .button:insensitive {
     background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(shade(@theme_bg_color, 0.95), 1.05)),
-                                     to (shade(shade(@theme_bg_color, 0.95), 0.97)));
+                                     from (shade(shade(@theme_bg_color, 1.055), 1.3)),
+                                     to (shade(shade(@theme_bg_color, 1.055), 0.92)));
 
     border-color: shade(@theme_bg_color, 0.8);
 }
 
 .button:insensitive:active {
     background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(shade(@theme_bg_color, 0.95), 1.05)),
-                                     to (shade(shade(@theme_bg_color, 0.95), 0.97)));
+                             from (shade(shade(@theme_bg_color, 0.95), 1.05)),
+                             to (shade(shade(@theme_bg_color, 0.95), 0.97)));
 }
 
 /* default button */
+
 .button.default {
     background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(alpha(@theme_selected_bg_color, 0.7), 1.05)),
-                                     to (shade(alpha(@theme_selected_bg_color, 0.7), 0.97)));
-
-    border-color: shade(@theme_selected_bg_color, 0.8);
+        from (shade(mix(@theme_focus_color, @theme_bg_color, 0.3), 1.3)),
+        to (shade(mix(@theme_focus_color, @theme_bg_color, 0.3), 0.92)));
 }
 
 .button.default:hover {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(mix(@theme_base_color, @theme_selected_bg_color, 0.7), 1.05)),
-                                     to (shade(mix(@theme_base_color, @theme_selected_bg_color, 0.7), 0.97)));
+
 }
 
 .button.default:active {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(alpha(@theme_selected_bg_color, 0.7), 1.05)),
-                                     to (shade(alpha(@theme_selected_bg_color, 0.7), 0.97)));
-
-    border-color: shade(@theme_selected_bg_color, 0.8);
 }
 
 .button.default:active:hover {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(mix(@theme_base_color, @theme_selected_bg_color, 0.7), 1.05)),
-                                     to (shade(mix(@theme_base_color, @theme_selected_bg_color, 0.7), 0.97)));
 }
 
 /* middle button */
@@ -453,6 +441,8 @@ column-header .button {
 
     border-color: shade(@theme_bg_color, 0.97);
     border-bottom-color: shade(@theme_bg_color, 0.8);
+    
+    padding: 3px 2px;
 }
 
 column-header .button:hover {
@@ -1603,8 +1593,8 @@ GtkTextView {
 .primary-toolbar .button *,
 .primary-toolbar .button {
     background-color: transparent;
-    background-image: none;
-    border-color: transparent;
+    /*background-image: none;*/
+    /*border-color: transparent;*/
     border-radius: 3px;
     border-width: 1px;
     padding: 2px;
@@ -1616,47 +1606,22 @@ GtkTextView {
 .primary-toolbar .button:hover,
 .primary-toolbar .button:active,
 .primary-toolbar .button:insensitive {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(@theme_bg_color, 1.15)),
-                                     to (shade(@theme_bg_color, 1.07)));
-
-    border-color: shade(@theme_bg_color, 0.7);
 }
 
 .primary-toolbar .button:active {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(shade(@theme_bg_color, 0.85), 1.05)),
-                                     to (shade(shade(@theme_bg_color, 0.85), 0.97)));
-
-    border-color: shade(@theme_bg_color, 0.6);
 }
 
 .primary-toolbar .button:active:hover {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(@theme_bg_color, 1.15)),
-                                     to (shade(@theme_bg_color, 1.07)));
-
-    border-top-color: shade(@theme_bg_color, 0.85);
-    border-right-color: shade(@theme_bg_color, 0.78);
-    border-bottom-color: shade(@theme_bg_color, 0.7);
-    border-left-color: shade(@theme_bg_color, 0.78);
 }
 
 .primary-toolbar .button:active:insensitive,
 .primary-toolbar .button:insensitive {
-    border-color: shade(@theme_bg_color, 0.8);
 }
 
 .primary-toolbar .button:insensitive {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(shade(@theme_bg_color, 0.95), 1.05)),
-                                     to (shade(shade(@theme_bg_color, 0.95), 0.97)));
 }
 
 .primary-toolbar .button:active:insensitive {
-    background-image: -gtk-gradient(linear, left top, left bottom,
-                                     from (shade(shade(@theme_bg_color, 0.95), 1.05)),
-                                     to (shade(shade(@theme_bg_color, 0.95), 0.97)));
 }
 
 .primary-toolbar .entry,

--- a/usr/share/themes/Mint-X/gtk-3.0/gtk.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk.css
@@ -7,6 +7,7 @@
 @define-color selected_fg_color #F5F5F5;
 @define-color tooltip_bg_color #F5F5B5;
 @define-color tooltip_fg_color #000000;
+@define-color focus_color #94b06f;
 @define-color bg_color_dark #c9c9c9;
 @define-color fg_color_dark #2c2c2c;
 
@@ -19,6 +20,7 @@
 @define-color theme_selected_fg_color @selected_fg_color;
 @define-color theme_tooltip_bg_color @tooltip_bg_color;
 @define-color theme_tooltip_fg_color @tooltip_fg_color;
+@define-color theme_focus_color @focus_color;
 
 /* shadow effects */
 @define-color light_shadow #fff;


### PR DESCRIPTION
Converts all button rendering to match the GTK2 murrine style in Mint-X as closely as possible.

Old:
![Old style](http://i.imgur.com/GX1ZxQF.png)

New:
![New Style](http://i.imgur.com/kHBm06S.png)
