### PR TITLE
Changed desktop font colors for better readability

### DIFF
--- a/usr/share/themes/Mint-X/gtk-3.0/apps/gnome-applications.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/apps/gnome-applications.css
@@ -104,8 +104,8 @@ NautilusWindow * {
 
 /* desktop mode */
 .nautilus-desktop.nautilus-canvas-item {
-    color: #EEEEEE;
-	text-shadow: 1px 1px alpha (#000000, 0.8);
+    color: #000000;
+	text-shadow: 1px 1px alpha (#FFFFFF, 0.8);
 }
 
 .nautilus-desktop.nautilus-canvas-item:active {


### PR DESCRIPTION
Previous desktop font color choice (soft white with shadow) Did not show up well on Mint default background (or any background). Changed default to higher contrast (full black, with white shadow). This allows the default text to show up clearly no matter the end users background color or image; which should be the primary concern of the default for simplicity and elegance.
