### PR TITLE
Fix checkboxes and radios in gtk3.14

### DIFF
--- a/usr/share/themes/Mint-X-Aqua/gtk-3.0/gtk-widgets-assets.css
+++ b/usr/share/themes/Mint-X-Aqua/gtk-3.0/gtk-widgets-assets.css
@@ -5,112 +5,112 @@
 .check,
 .check row:selected,
 .check row:selected:focus {
-    background-image: -gtk-scaled(url("assets/checkbox-unchecked.png"), url("assets/checkbox-unchecked@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked.png"), url("assets/checkbox-unchecked@2.png"));
 }
 
 .check:insensitive,
 .check row:selected:insensitive,
 .check row:selected:focus:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-unchecked-insensitive.png"), url("assets/checkbox-unchecked-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-insensitive.png"), url("assets/checkbox-unchecked-insensitive@2.png"));
 }
 
-.check:active,
-.check row:selected:active,
-.check row:selected:focus:active {
-    background-image: -gtk-scaled(url("assets/checkbox-checked.png"), url("assets/checkbox-checked@2.png"));
+.check:active, .check:checked,
+.check row:selected:active, .check row:selected:checked,
+.check row:selected:focus:active, .check row:selected:focus:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked.png"), url("assets/checkbox-checked@2.png"));
 }
 
-.check:active:insensitive,
-.check row:selected:active:insensitive,
-.check row:selected:focus:active:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-checked-insensitive.png"), url("assets/checkbox-checked-insensitive@2.png"));
+.check:active:insensitive, .check:checked:insensitive,
+.check row:selected:active:insensitive, .check row:selected:checked:insensitive,
+.check row:selected:focus:active:insensitive, .check row:selected:focus:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-insensitive.png"), url("assets/checkbox-checked-insensitive@2.png"));
 }
 
 .check:inconsistent,
 .check row:selected:inconsistent,
 .check row:selected:focus:inconsistent {
-    background-image: -gtk-scaled(url("assets/checkbox-mixed.png"), url("assets/checkbox-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed.png"), url("assets/checkbox-mixed@2.png"));
 }
 
 .check:inconsistent:insensitive,
 .check row:selected:inconsistent:insensitive,
 .check row:selected:focus:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-mixed-insensitive.png"), url("assets/checkbox-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-insensitive.png"), url("assets/checkbox-mixed-insensitive@2.png"));
 }
 
 .radio,
 .radio row:selected,
 .radio row:selected:focus {
-    background-image: -gtk-scaled(url("assets/radio-unselected.png"), url("assets/radio-unselected@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-unselected.png"), url("assets/radio-unselected@2.png"));
 }
 
 .radio:insensitive,
 .radio row:selected:insensitive,
 .radio row:selected:focus:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-unselected-insensitive.png"), url("assets/radio-unselected-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-unselected-insensitive.png"), url("assets/radio-unselected-insensitive@2.png"));
 }
 
-.radio:active,
-.radio row:selected:active,
-.radio row:selected:focus:active {
-    background-image: -gtk-scaled(url("assets/radio-selected.png"), url("assets/radio-selected@2.png"));
+.radio:active, .radio:checked,
+.radio row:selected:active, .radio row:selected:checked,
+.radio row:selected:focus:active, .radio row:selected:focus:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-selected.png"), url("assets/radio-selected@2.png"));
 }
 
-.radio:active:insensitive,
-.radio row:selected:active:insensitive,
-.radio row:selected:focus:active:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-selected-insensitive.png"), url("assets/radio-selected-insensitive@2.png"));
+.radio:active:insensitive, .radio:checked:insensitive,
+.radio row:selected:active:insensitive, .radio row:selected:checked:insensitive,
+.radio row:selected:focus:active:insensitive, .radio row:selected:focus:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-selected-insensitive.png"), url("assets/radio-selected-insensitive@2.png"));
 }
 
 .radio:inconsistent,
 .radio row:selected:inconsistent,
 .radio row:selected:focus:inconsistent {
-    background-image: -gtk-scaled(url("assets/radio-mixed.png"), url("assets/radio-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed.png"), url("assets/radio-mixed@2.png"));
 }
 
 .radio:inconsistent:insensitive,
 .radio row:selected:inconsistent:insensitive,
 .radio row:selected:focus:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-mixed-insensitive.png"), url("assets/radio-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-insensitive.png"), url("assets/radio-mixed-insensitive@2.png"));
 }
 
-.menuitem.check:active {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked.png"), url("assets/menuitem-checkbox-checked@2.png"));
+.menuitem.check:active, .menuitem.check:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked.png"), url("assets/menuitem-checkbox-checked@2.png"));
 }
 
-.menuitem.check:active:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked-selected.png"), url("assets/menuitem-checkbox-checked-selected@2.png"));
+.menuitem.check:active:hover, .menuitem.check:checked:hover {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked-selected.png"), url("assets/menuitem-checkbox-checked-selected@2.png"));
 }
 
-.menuitem.check:active:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked-insensitive.png"), url("assets/menuitem-checkbox-checked-insensitive@2.png"));
+.menuitem.check:active:insensitive, .menuitem.check:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked-insensitive.png"), url("assets/menuitem-checkbox-checked-insensitive@2.png"));
 }
 
 .menuitem.check:inconsistent,
 .menuitem.radio:inconsistent {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed.png"), url("assets/menuitem-checkbox-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed.png"), url("assets/menuitem-checkbox-mixed@2.png"));
 }
 
 .menuitem.check:inconsistent:insensitive,
 .menuitem.radio:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed-insensitive.png"), url("assets/menuitem-checkbox-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed-insensitive.png"), url("assets/menuitem-checkbox-mixed-insensitive@2.png"));
 }
 
 .menuitem.check:inconsistent:hover,
 .menuitem.radio:inconsistent:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed-selected.png"), url("assets/menuitem-checkbox-mixed-selected@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed-selected.png"), url("assets/menuitem-checkbox-mixed-selected@2.png"));
 }
 
-.menuitem.radio:active {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked.png"), url("assets/menuitem-radio-checked@2.png"));
+.menuitem.radio:active, .menuitem.radio:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked.png"), url("assets/menuitem-radio-checked@2.png"));
 }
 
-.menuitem.radio:active:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked-selected.png"), url("assets/menuitem-radio-checked-selected@2.png"));
+.menuitem.radio:active:hover, .menuitem.radio:checked:hover {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked-selected.png"), url("assets/menuitem-radio-checked-selected@2.png"));
 }
 
-.menuitem.radio:active:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked-insensitive.png"), url("assets/menuitem-radio-checked-insensitive@2.png"));
+.menuitem.radio:active:insensitive, .menuitem.radio:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked-insensitive.png"), url("assets/menuitem-radio-checked-insensitive@2.png"));
 }
 
 /******************

--- a/usr/share/themes/Mint-X-Blue/gtk-3.0/gtk-widgets-assets.css
+++ b/usr/share/themes/Mint-X-Blue/gtk-3.0/gtk-widgets-assets.css
@@ -5,112 +5,112 @@
 .check,
 .check row:selected,
 .check row:selected:focus {
-    background-image: -gtk-scaled(url("assets/checkbox-unchecked.png"), url("assets/checkbox-unchecked@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked.png"), url("assets/checkbox-unchecked@2.png"));
 }
 
 .check:insensitive,
 .check row:selected:insensitive,
 .check row:selected:focus:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-unchecked-insensitive.png"), url("assets/checkbox-unchecked-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-insensitive.png"), url("assets/checkbox-unchecked-insensitive@2.png"));
 }
 
-.check:active,
-.check row:selected:active,
-.check row:selected:focus:active {
-    background-image: -gtk-scaled(url("assets/checkbox-checked.png"), url("assets/checkbox-checked@2.png"));
+.check:active, .check:checked,
+.check row:selected:active, .check row:selected:checked,
+.check row:selected:focus:active, .check row:selected:focus:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked.png"), url("assets/checkbox-checked@2.png"));
 }
 
-.check:active:insensitive,
-.check row:selected:active:insensitive,
-.check row:selected:focus:active:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-checked-insensitive.png"), url("assets/checkbox-checked-insensitive@2.png"));
+.check:active:insensitive, .check:checked:insensitive,
+.check row:selected:active:insensitive, .check row:selected:checked:insensitive,
+.check row:selected:focus:active:insensitive, .check row:selected:focus:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-insensitive.png"), url("assets/checkbox-checked-insensitive@2.png"));
 }
 
 .check:inconsistent,
 .check row:selected:inconsistent,
 .check row:selected:focus:inconsistent {
-    background-image: -gtk-scaled(url("assets/checkbox-mixed.png"), url("assets/checkbox-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed.png"), url("assets/checkbox-mixed@2.png"));
 }
 
 .check:inconsistent:insensitive,
 .check row:selected:inconsistent:insensitive,
 .check row:selected:focus:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-mixed-insensitive.png"), url("assets/checkbox-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-insensitive.png"), url("assets/checkbox-mixed-insensitive@2.png"));
 }
 
 .radio,
 .radio row:selected,
 .radio row:selected:focus {
-    background-image: -gtk-scaled(url("assets/radio-unselected.png"), url("assets/radio-unselected@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-unselected.png"), url("assets/radio-unselected@2.png"));
 }
 
 .radio:insensitive,
 .radio row:selected:insensitive,
 .radio row:selected:focus:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-unselected-insensitive.png"), url("assets/radio-unselected-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-unselected-insensitive.png"), url("assets/radio-unselected-insensitive@2.png"));
 }
 
-.radio:active,
-.radio row:selected:active,
-.radio row:selected:focus:active {
-    background-image: -gtk-scaled(url("assets/radio-selected.png"), url("assets/radio-selected@2.png"));
+.radio:active, .radio:checked,
+.radio row:selected:active, .radio row:selected:checked,
+.radio row:selected:focus:active, .radio row:selected:focus:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-selected.png"), url("assets/radio-selected@2.png"));
 }
 
-.radio:active:insensitive,
-.radio row:selected:active:insensitive,
-.radio row:selected:focus:active:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-selected-insensitive.png"), url("assets/radio-selected-insensitive@2.png"));
+.radio:active:insensitive, .radio:checked:insensitive,
+.radio row:selected:active:insensitive, .radio row:selected:checked:insensitive,
+.radio row:selected:focus:active:insensitive, .radio row:selected:focus:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-selected-insensitive.png"), url("assets/radio-selected-insensitive@2.png"));
 }
 
 .radio:inconsistent,
 .radio row:selected:inconsistent,
 .radio row:selected:focus:inconsistent {
-    background-image: -gtk-scaled(url("assets/radio-mixed.png"), url("assets/radio-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed.png"), url("assets/radio-mixed@2.png"));
 }
 
 .radio:inconsistent:insensitive,
 .radio row:selected:inconsistent:insensitive,
 .radio row:selected:focus:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-mixed-insensitive.png"), url("assets/radio-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-insensitive.png"), url("assets/radio-mixed-insensitive@2.png"));
 }
 
-.menuitem.check:active {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked.png"), url("assets/menuitem-checkbox-checked@2.png"));
+.menuitem.check:active, .menuitem.check:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked.png"), url("assets/menuitem-checkbox-checked@2.png"));
 }
 
-.menuitem.check:active:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked-selected.png"), url("assets/menuitem-checkbox-checked-selected@2.png"));
+.menuitem.check:active:hover, .menuitem.check:checked:hover {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked-selected.png"), url("assets/menuitem-checkbox-checked-selected@2.png"));
 }
 
-.menuitem.check:active:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked-insensitive.png"), url("assets/menuitem-checkbox-checked-insensitive@2.png"));
+.menuitem.check:active:insensitive, .menuitem.check:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked-insensitive.png"), url("assets/menuitem-checkbox-checked-insensitive@2.png"));
 }
 
 .menuitem.check:inconsistent,
 .menuitem.radio:inconsistent {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed.png"), url("assets/menuitem-checkbox-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed.png"), url("assets/menuitem-checkbox-mixed@2.png"));
 }
 
 .menuitem.check:inconsistent:insensitive,
 .menuitem.radio:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed-insensitive.png"), url("assets/menuitem-checkbox-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed-insensitive.png"), url("assets/menuitem-checkbox-mixed-insensitive@2.png"));
 }
 
 .menuitem.check:inconsistent:hover,
 .menuitem.radio:inconsistent:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed-selected.png"), url("assets/menuitem-checkbox-mixed-selected@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed-selected.png"), url("assets/menuitem-checkbox-mixed-selected@2.png"));
 }
 
-.menuitem.radio:active {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked.png"), url("assets/menuitem-radio-checked@2.png"));
+.menuitem.radio:active, .menuitem.radio:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked.png"), url("assets/menuitem-radio-checked@2.png"));
 }
 
-.menuitem.radio:active:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked-selected.png"), url("assets/menuitem-radio-checked-selected@2.png"));
+.menuitem.radio:active:hover, .menuitem.radio:checked:hover {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked-selected.png"), url("assets/menuitem-radio-checked-selected@2.png"));
 }
 
-.menuitem.radio:active:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked-insensitive.png"), url("assets/menuitem-radio-checked-insensitive@2.png"));
+.menuitem.radio:active:insensitive, .menuitem.radio:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked-insensitive.png"), url("assets/menuitem-radio-checked-insensitive@2.png"));
 }
 
 /******************

--- a/usr/share/themes/Mint-X-Brown/gtk-3.0/gtk-widgets-assets.css
+++ b/usr/share/themes/Mint-X-Brown/gtk-3.0/gtk-widgets-assets.css
@@ -5,112 +5,112 @@
 .check,
 .check row:selected,
 .check row:selected:focus {
-    background-image: -gtk-scaled(url("assets/checkbox-unchecked.png"), url("assets/checkbox-unchecked@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked.png"), url("assets/checkbox-unchecked@2.png"));
 }
 
 .check:insensitive,
 .check row:selected:insensitive,
 .check row:selected:focus:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-unchecked-insensitive.png"), url("assets/checkbox-unchecked-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-insensitive.png"), url("assets/checkbox-unchecked-insensitive@2.png"));
 }
 
-.check:active,
-.check row:selected:active,
-.check row:selected:focus:active {
-    background-image: -gtk-scaled(url("assets/checkbox-checked.png"), url("assets/checkbox-checked@2.png"));
+.check:active, .check:checked,
+.check row:selected:active, .check row:selected:checked,
+.check row:selected:focus:active, .check row:selected:focus:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked.png"), url("assets/checkbox-checked@2.png"));
 }
 
-.check:active:insensitive,
-.check row:selected:active:insensitive,
-.check row:selected:focus:active:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-checked-insensitive.png"), url("assets/checkbox-checked-insensitive@2.png"));
+.check:active:insensitive, .check:checked:insensitive,
+.check row:selected:active:insensitive, .check row:selected:checked:insensitive,
+.check row:selected:focus:active:insensitive, .check row:selected:focus:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-insensitive.png"), url("assets/checkbox-checked-insensitive@2.png"));
 }
 
 .check:inconsistent,
 .check row:selected:inconsistent,
 .check row:selected:focus:inconsistent {
-    background-image: -gtk-scaled(url("assets/checkbox-mixed.png"), url("assets/checkbox-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed.png"), url("assets/checkbox-mixed@2.png"));
 }
 
 .check:inconsistent:insensitive,
 .check row:selected:inconsistent:insensitive,
 .check row:selected:focus:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-mixed-insensitive.png"), url("assets/checkbox-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-insensitive.png"), url("assets/checkbox-mixed-insensitive@2.png"));
 }
 
 .radio,
 .radio row:selected,
 .radio row:selected:focus {
-    background-image: -gtk-scaled(url("assets/radio-unselected.png"), url("assets/radio-unselected@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-unselected.png"), url("assets/radio-unselected@2.png"));
 }
 
 .radio:insensitive,
 .radio row:selected:insensitive,
 .radio row:selected:focus:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-unselected-insensitive.png"), url("assets/radio-unselected-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-unselected-insensitive.png"), url("assets/radio-unselected-insensitive@2.png"));
 }
 
-.radio:active,
-.radio row:selected:active,
-.radio row:selected:focus:active {
-    background-image: -gtk-scaled(url("assets/radio-selected.png"), url("assets/radio-selected@2.png"));
+.radio:active, .radio:checked,
+.radio row:selected:active, .radio row:selected:checked,
+.radio row:selected:focus:active, .radio row:selected:focus:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-selected.png"), url("assets/radio-selected@2.png"));
 }
 
-.radio:active:insensitive,
-.radio row:selected:active:insensitive,
-.radio row:selected:focus:active:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-selected-insensitive.png"), url("assets/radio-selected-insensitive@2.png"));
+.radio:active:insensitive, .radio:checked:insensitive,
+.radio row:selected:active:insensitive, .radio row:selected:checked:insensitive,
+.radio row:selected:focus:active:insensitive, .radio row:selected:focus:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-selected-insensitive.png"), url("assets/radio-selected-insensitive@2.png"));
 }
 
 .radio:inconsistent,
 .radio row:selected:inconsistent,
 .radio row:selected:focus:inconsistent {
-    background-image: -gtk-scaled(url("assets/radio-mixed.png"), url("assets/radio-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed.png"), url("assets/radio-mixed@2.png"));
 }
 
 .radio:inconsistent:insensitive,
 .radio row:selected:inconsistent:insensitive,
 .radio row:selected:focus:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-mixed-insensitive.png"), url("assets/radio-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-insensitive.png"), url("assets/radio-mixed-insensitive@2.png"));
 }
 
-.menuitem.check:active {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked.png"), url("assets/menuitem-checkbox-checked@2.png"));
+.menuitem.check:active, .menuitem.check:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked.png"), url("assets/menuitem-checkbox-checked@2.png"));
 }
 
-.menuitem.check:active:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked-selected.png"), url("assets/menuitem-checkbox-checked-selected@2.png"));
+.menuitem.check:active:hover, .menuitem.check:checked:hover {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked-selected.png"), url("assets/menuitem-checkbox-checked-selected@2.png"));
 }
 
-.menuitem.check:active:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked-insensitive.png"), url("assets/menuitem-checkbox-checked-insensitive@2.png"));
+.menuitem.check:active:insensitive, .menuitem.check:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked-insensitive.png"), url("assets/menuitem-checkbox-checked-insensitive@2.png"));
 }
 
 .menuitem.check:inconsistent,
 .menuitem.radio:inconsistent {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed.png"), url("assets/menuitem-checkbox-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed.png"), url("assets/menuitem-checkbox-mixed@2.png"));
 }
 
 .menuitem.check:inconsistent:insensitive,
 .menuitem.radio:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed-insensitive.png"), url("assets/menuitem-checkbox-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed-insensitive.png"), url("assets/menuitem-checkbox-mixed-insensitive@2.png"));
 }
 
 .menuitem.check:inconsistent:hover,
 .menuitem.radio:inconsistent:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed-selected.png"), url("assets/menuitem-checkbox-mixed-selected@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed-selected.png"), url("assets/menuitem-checkbox-mixed-selected@2.png"));
 }
 
-.menuitem.radio:active {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked.png"), url("assets/menuitem-radio-checked@2.png"));
+.menuitem.radio:active, .menuitem.radio:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked.png"), url("assets/menuitem-radio-checked@2.png"));
 }
 
-.menuitem.radio:active:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked-selected.png"), url("assets/menuitem-radio-checked-selected@2.png"));
+.menuitem.radio:active:hover, .menuitem.radio:checked:hover {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked-selected.png"), url("assets/menuitem-radio-checked-selected@2.png"));
 }
 
-.menuitem.radio:active:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked-insensitive.png"), url("assets/menuitem-radio-checked-insensitive@2.png"));
+.menuitem.radio:active:insensitive, .menuitem.radio:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked-insensitive.png"), url("assets/menuitem-radio-checked-insensitive@2.png"));
 }
 
 /******************

--- a/usr/share/themes/Mint-X-Orange/gtk-3.0/gtk-widgets-assets.css
+++ b/usr/share/themes/Mint-X-Orange/gtk-3.0/gtk-widgets-assets.css
@@ -5,112 +5,112 @@
 .check,
 .check row:selected,
 .check row:selected:focus {
-    background-image: -gtk-scaled(url("assets/checkbox-unchecked.png"), url("assets/checkbox-unchecked@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked.png"), url("assets/checkbox-unchecked@2.png"));
 }
 
 .check:insensitive,
 .check row:selected:insensitive,
 .check row:selected:focus:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-unchecked-insensitive.png"), url("assets/checkbox-unchecked-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-insensitive.png"), url("assets/checkbox-unchecked-insensitive@2.png"));
 }
 
-.check:active,
-.check row:selected:active,
-.check row:selected:focus:active {
-    background-image: -gtk-scaled(url("assets/checkbox-checked.png"), url("assets/checkbox-checked@2.png"));
+.check:active, .check:checked,
+.check row:selected:active, .check row:selected:checked,
+.check row:selected:focus:active, .check row:selected:focus:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked.png"), url("assets/checkbox-checked@2.png"));
 }
 
-.check:active:insensitive,
-.check row:selected:active:insensitive,
-.check row:selected:focus:active:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-checked-insensitive.png"), url("assets/checkbox-checked-insensitive@2.png"));
+.check:active:insensitive, .check:checked:insensitive,
+.check row:selected:active:insensitive, .check row:selected:checked:insensitive,
+.check row:selected:focus:active:insensitive, .check row:selected:focus:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-insensitive.png"), url("assets/checkbox-checked-insensitive@2.png"));
 }
 
 .check:inconsistent,
 .check row:selected:inconsistent,
 .check row:selected:focus:inconsistent {
-    background-image: -gtk-scaled(url("assets/checkbox-mixed.png"), url("assets/checkbox-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed.png"), url("assets/checkbox-mixed@2.png"));
 }
 
 .check:inconsistent:insensitive,
 .check row:selected:inconsistent:insensitive,
 .check row:selected:focus:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-mixed-insensitive.png"), url("assets/checkbox-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-insensitive.png"), url("assets/checkbox-mixed-insensitive@2.png"));
 }
 
 .radio,
 .radio row:selected,
 .radio row:selected:focus {
-    background-image: -gtk-scaled(url("assets/radio-unselected.png"), url("assets/radio-unselected@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-unselected.png"), url("assets/radio-unselected@2.png"));
 }
 
 .radio:insensitive,
 .radio row:selected:insensitive,
 .radio row:selected:focus:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-unselected-insensitive.png"), url("assets/radio-unselected-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-unselected-insensitive.png"), url("assets/radio-unselected-insensitive@2.png"));
 }
 
-.radio:active,
-.radio row:selected:active,
-.radio row:selected:focus:active {
-    background-image: -gtk-scaled(url("assets/radio-selected.png"), url("assets/radio-selected@2.png"));
+.radio:active, .radio:checked,
+.radio row:selected:active, .radio row:selected:checked,
+.radio row:selected:focus:active, .radio row:selected:focus:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-selected.png"), url("assets/radio-selected@2.png"));
 }
 
-.radio:active:insensitive,
-.radio row:selected:active:insensitive,
-.radio row:selected:focus:active:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-selected-insensitive.png"), url("assets/radio-selected-insensitive@2.png"));
+.radio:active:insensitive, .radio:checked:insensitive,
+.radio row:selected:active:insensitive, .radio row:selected:checked:insensitive,
+.radio row:selected:focus:active:insensitive, .radio row:selected:focus:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-selected-insensitive.png"), url("assets/radio-selected-insensitive@2.png"));
 }
 
 .radio:inconsistent,
 .radio row:selected:inconsistent,
 .radio row:selected:focus:inconsistent {
-    background-image: -gtk-scaled(url("assets/radio-mixed.png"), url("assets/radio-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed.png"), url("assets/radio-mixed@2.png"));
 }
 
 .radio:inconsistent:insensitive,
 .radio row:selected:inconsistent:insensitive,
 .radio row:selected:focus:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-mixed-insensitive.png"), url("assets/radio-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-insensitive.png"), url("assets/radio-mixed-insensitive@2.png"));
 }
 
-.menuitem.check:active {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked.png"), url("assets/menuitem-checkbox-checked@2.png"));
+.menuitem.check:active, .menuitem.check:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked.png"), url("assets/menuitem-checkbox-checked@2.png"));
 }
 
-.menuitem.check:active:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked-selected.png"), url("assets/menuitem-checkbox-checked-selected@2.png"));
+.menuitem.check:active:hover, .menuitem.check:checked:hover {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked-selected.png"), url("assets/menuitem-checkbox-checked-selected@2.png"));
 }
 
-.menuitem.check:active:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked-insensitive.png"), url("assets/menuitem-checkbox-checked-insensitive@2.png"));
+.menuitem.check:active:insensitive, .menuitem.check:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked-insensitive.png"), url("assets/menuitem-checkbox-checked-insensitive@2.png"));
 }
 
 .menuitem.check:inconsistent,
 .menuitem.radio:inconsistent {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed.png"), url("assets/menuitem-checkbox-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed.png"), url("assets/menuitem-checkbox-mixed@2.png"));
 }
 
 .menuitem.check:inconsistent:insensitive,
 .menuitem.radio:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed-insensitive.png"), url("assets/menuitem-checkbox-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed-insensitive.png"), url("assets/menuitem-checkbox-mixed-insensitive@2.png"));
 }
 
 .menuitem.check:inconsistent:hover,
 .menuitem.radio:inconsistent:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed-selected.png"), url("assets/menuitem-checkbox-mixed-selected@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed-selected.png"), url("assets/menuitem-checkbox-mixed-selected@2.png"));
 }
 
-.menuitem.radio:active {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked.png"), url("assets/menuitem-radio-checked@2.png"));
+.menuitem.radio:active, .menuitem.radio:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked.png"), url("assets/menuitem-radio-checked@2.png"));
 }
 
-.menuitem.radio:active:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked-selected.png"), url("assets/menuitem-radio-checked-selected@2.png"));
+.menuitem.radio:active:hover, .menuitem.radio:checked:hover {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked-selected.png"), url("assets/menuitem-radio-checked-selected@2.png"));
 }
 
-.menuitem.radio:active:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked-insensitive.png"), url("assets/menuitem-radio-checked-insensitive@2.png"));
+.menuitem.radio:active:insensitive, .menuitem.radio:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked-insensitive.png"), url("assets/menuitem-radio-checked-insensitive@2.png"));
 }
 
 /******************

--- a/usr/share/themes/Mint-X-Pink/gtk-3.0/gtk-widgets-assets.css
+++ b/usr/share/themes/Mint-X-Pink/gtk-3.0/gtk-widgets-assets.css
@@ -5,112 +5,112 @@
 .check,
 .check row:selected,
 .check row:selected:focus {
-    background-image: -gtk-scaled(url("assets/checkbox-unchecked.png"), url("assets/checkbox-unchecked@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked.png"), url("assets/checkbox-unchecked@2.png"));
 }
 
 .check:insensitive,
 .check row:selected:insensitive,
 .check row:selected:focus:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-unchecked-insensitive.png"), url("assets/checkbox-unchecked-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-insensitive.png"), url("assets/checkbox-unchecked-insensitive@2.png"));
 }
 
-.check:active,
-.check row:selected:active,
-.check row:selected:focus:active {
-    background-image: -gtk-scaled(url("assets/checkbox-checked.png"), url("assets/checkbox-checked@2.png"));
+.check:active, .check:checked,
+.check row:selected:active, .check row:selected:checked,
+.check row:selected:focus:active, .check row:selected:focus:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked.png"), url("assets/checkbox-checked@2.png"));
 }
 
-.check:active:insensitive,
-.check row:selected:active:insensitive,
-.check row:selected:focus:active:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-checked-insensitive.png"), url("assets/checkbox-checked-insensitive@2.png"));
+.check:active:insensitive, .check:checked:insensitive,
+.check row:selected:active:insensitive, .check row:selected:checked:insensitive,
+.check row:selected:focus:active:insensitive, .check row:selected:focus:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-insensitive.png"), url("assets/checkbox-checked-insensitive@2.png"));
 }
 
 .check:inconsistent,
 .check row:selected:inconsistent,
 .check row:selected:focus:inconsistent {
-    background-image: -gtk-scaled(url("assets/checkbox-mixed.png"), url("assets/checkbox-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed.png"), url("assets/checkbox-mixed@2.png"));
 }
 
 .check:inconsistent:insensitive,
 .check row:selected:inconsistent:insensitive,
 .check row:selected:focus:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-mixed-insensitive.png"), url("assets/checkbox-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-insensitive.png"), url("assets/checkbox-mixed-insensitive@2.png"));
 }
 
 .radio,
 .radio row:selected,
 .radio row:selected:focus {
-    background-image: -gtk-scaled(url("assets/radio-unselected.png"), url("assets/radio-unselected@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-unselected.png"), url("assets/radio-unselected@2.png"));
 }
 
 .radio:insensitive,
 .radio row:selected:insensitive,
 .radio row:selected:focus:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-unselected-insensitive.png"), url("assets/radio-unselected-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-unselected-insensitive.png"), url("assets/radio-unselected-insensitive@2.png"));
 }
 
-.radio:active,
-.radio row:selected:active,
-.radio row:selected:focus:active {
-    background-image: -gtk-scaled(url("assets/radio-selected.png"), url("assets/radio-selected@2.png"));
+.radio:active, .radio:checked,
+.radio row:selected:active, .radio row:selected:checked,
+.radio row:selected:focus:active, .radio row:selected:focus:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-selected.png"), url("assets/radio-selected@2.png"));
 }
 
-.radio:active:insensitive,
-.radio row:selected:active:insensitive,
-.radio row:selected:focus:active:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-selected-insensitive.png"), url("assets/radio-selected-insensitive@2.png"));
+.radio:active:insensitive, .radio:checked:insensitive,
+.radio row:selected:active:insensitive, .radio row:selected:checked:insensitive,
+.radio row:selected:focus:active:insensitive, .radio row:selected:focus:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-selected-insensitive.png"), url("assets/radio-selected-insensitive@2.png"));
 }
 
 .radio:inconsistent,
 .radio row:selected:inconsistent,
 .radio row:selected:focus:inconsistent {
-    background-image: -gtk-scaled(url("assets/radio-mixed.png"), url("assets/radio-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed.png"), url("assets/radio-mixed@2.png"));
 }
 
 .radio:inconsistent:insensitive,
 .radio row:selected:inconsistent:insensitive,
 .radio row:selected:focus:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-mixed-insensitive.png"), url("assets/radio-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-insensitive.png"), url("assets/radio-mixed-insensitive@2.png"));
 }
 
-.menuitem.check:active {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked.png"), url("assets/menuitem-checkbox-checked@2.png"));
+.menuitem.check:active, .menuitem.check:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked.png"), url("assets/menuitem-checkbox-checked@2.png"));
 }
 
-.menuitem.check:active:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked-selected.png"), url("assets/menuitem-checkbox-checked-selected@2.png"));
+.menuitem.check:active:hover, .menuitem.check:checked:hover {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked-selected.png"), url("assets/menuitem-checkbox-checked-selected@2.png"));
 }
 
-.menuitem.check:active:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked-insensitive.png"), url("assets/menuitem-checkbox-checked-insensitive@2.png"));
+.menuitem.check:active:insensitive, .menuitem.check:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked-insensitive.png"), url("assets/menuitem-checkbox-checked-insensitive@2.png"));
 }
 
 .menuitem.check:inconsistent,
 .menuitem.radio:inconsistent {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed.png"), url("assets/menuitem-checkbox-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed.png"), url("assets/menuitem-checkbox-mixed@2.png"));
 }
 
 .menuitem.check:inconsistent:insensitive,
 .menuitem.radio:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed-insensitive.png"), url("assets/menuitem-checkbox-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed-insensitive.png"), url("assets/menuitem-checkbox-mixed-insensitive@2.png"));
 }
 
 .menuitem.check:inconsistent:hover,
 .menuitem.radio:inconsistent:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed-selected.png"), url("assets/menuitem-checkbox-mixed-selected@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed-selected.png"), url("assets/menuitem-checkbox-mixed-selected@2.png"));
 }
 
-.menuitem.radio:active {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked.png"), url("assets/menuitem-radio-checked@2.png"));
+.menuitem.radio:active, .menuitem.radio:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked.png"), url("assets/menuitem-radio-checked@2.png"));
 }
 
-.menuitem.radio:active:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked-selected.png"), url("assets/menuitem-radio-checked-selected@2.png"));
+.menuitem.radio:active:hover, .menuitem.radio:checked:hover {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked-selected.png"), url("assets/menuitem-radio-checked-selected@2.png"));
 }
 
-.menuitem.radio:active:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked-insensitive.png"), url("assets/menuitem-radio-checked-insensitive@2.png"));
+.menuitem.radio:active:insensitive, .menuitem.radio:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked-insensitive.png"), url("assets/menuitem-radio-checked-insensitive@2.png"));
 }
 
 /******************

--- a/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets-assets.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets-assets.css
@@ -5,112 +5,112 @@
 .check,
 .check row:selected,
 .check row:selected:focus {
-    background-image: -gtk-scaled(url("assets/checkbox-unchecked.png"), url("assets/checkbox-unchecked@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked.png"), url("assets/checkbox-unchecked@2.png"));
 }
 
 .check:insensitive,
 .check row:selected:insensitive,
 .check row:selected:focus:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-unchecked-insensitive.png"), url("assets/checkbox-unchecked-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-unchecked-insensitive.png"), url("assets/checkbox-unchecked-insensitive@2.png"));
 }
 
-.check:active,
-.check row:selected:active,
-.check row:selected:focus:active {
-    background-image: -gtk-scaled(url("assets/checkbox-checked.png"), url("assets/checkbox-checked@2.png"));
+.check:active, .check:checked,
+.check row:selected:active, .check row:selected:checked,
+.check row:selected:focus:active, .check row:selected:focus:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked.png"), url("assets/checkbox-checked@2.png"));
 }
 
-.check:active:insensitive,
-.check row:selected:active:insensitive,
-.check row:selected:focus:active:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-checked-insensitive.png"), url("assets/checkbox-checked-insensitive@2.png"));
+.check:active:insensitive, .check:checked:insensitive,
+.check row:selected:active:insensitive, .check row:selected:checked:insensitive,
+.check row:selected:focus:active:insensitive, .check row:selected:focus:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-checked-insensitive.png"), url("assets/checkbox-checked-insensitive@2.png"));
 }
 
 .check:inconsistent,
 .check row:selected:inconsistent,
 .check row:selected:focus:inconsistent {
-    background-image: -gtk-scaled(url("assets/checkbox-mixed.png"), url("assets/checkbox-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed.png"), url("assets/checkbox-mixed@2.png"));
 }
 
 .check:inconsistent:insensitive,
 .check row:selected:inconsistent:insensitive,
 .check row:selected:focus:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/checkbox-mixed-insensitive.png"), url("assets/checkbox-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/checkbox-mixed-insensitive.png"), url("assets/checkbox-mixed-insensitive@2.png"));
 }
 
 .radio,
 .radio row:selected,
 .radio row:selected:focus {
-    background-image: -gtk-scaled(url("assets/radio-unselected.png"), url("assets/radio-unselected@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-unselected.png"), url("assets/radio-unselected@2.png"));
 }
 
 .radio:insensitive,
 .radio row:selected:insensitive,
 .radio row:selected:focus:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-unselected-insensitive.png"), url("assets/radio-unselected-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-unselected-insensitive.png"), url("assets/radio-unselected-insensitive@2.png"));
 }
 
-.radio:active,
-.radio row:selected:active,
-.radio row:selected:focus:active {
-    background-image: -gtk-scaled(url("assets/radio-selected.png"), url("assets/radio-selected@2.png"));
+.radio:active, .radio:checked,
+.radio row:selected:active, .radio row:selected:checked,
+.radio row:selected:focus:active, .radio row:selected:focus:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-selected.png"), url("assets/radio-selected@2.png"));
 }
 
-.radio:active:insensitive,
-.radio row:selected:active:insensitive,
-.radio row:selected:focus:active:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-selected-insensitive.png"), url("assets/radio-selected-insensitive@2.png"));
+.radio:active:insensitive, .radio:checked:insensitive,
+.radio row:selected:active:insensitive, .radio row:selected:checked:insensitive,
+.radio row:selected:focus:active:insensitive, .radio row:selected:focus:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-selected-insensitive.png"), url("assets/radio-selected-insensitive@2.png"));
 }
 
 .radio:inconsistent,
 .radio row:selected:inconsistent,
 .radio row:selected:focus:inconsistent {
-    background-image: -gtk-scaled(url("assets/radio-mixed.png"), url("assets/radio-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed.png"), url("assets/radio-mixed@2.png"));
 }
 
 .radio:inconsistent:insensitive,
 .radio row:selected:inconsistent:insensitive,
 .radio row:selected:focus:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/radio-mixed-insensitive.png"), url("assets/radio-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/radio-mixed-insensitive.png"), url("assets/radio-mixed-insensitive@2.png"));
 }
 
-.menuitem.check:active {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked.png"), url("assets/menuitem-checkbox-checked@2.png"));
+.menuitem.check:active, .menuitem.check:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked.png"), url("assets/menuitem-checkbox-checked@2.png"));
 }
 
-.menuitem.check:active:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked-selected.png"), url("assets/menuitem-checkbox-checked-selected@2.png"));
+.menuitem.check:active:hover, .menuitem.check:checked:hover {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked-selected.png"), url("assets/menuitem-checkbox-checked-selected@2.png"));
 }
 
-.menuitem.check:active:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-checked-insensitive.png"), url("assets/menuitem-checkbox-checked-insensitive@2.png"));
+.menuitem.check:active:insensitive, .menuitem.check:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-checked-insensitive.png"), url("assets/menuitem-checkbox-checked-insensitive@2.png"));
 }
 
 .menuitem.check:inconsistent,
 .menuitem.radio:inconsistent {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed.png"), url("assets/menuitem-checkbox-mixed@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed.png"), url("assets/menuitem-checkbox-mixed@2.png"));
 }
 
 .menuitem.check:inconsistent:insensitive,
 .menuitem.radio:inconsistent:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed-insensitive.png"), url("assets/menuitem-checkbox-mixed-insensitive@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed-insensitive.png"), url("assets/menuitem-checkbox-mixed-insensitive@2.png"));
 }
 
 .menuitem.check:inconsistent:hover,
 .menuitem.radio:inconsistent:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-checkbox-mixed-selected.png"), url("assets/menuitem-checkbox-mixed-selected@2.png"));
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-checkbox-mixed-selected.png"), url("assets/menuitem-checkbox-mixed-selected@2.png"));
 }
 
-.menuitem.radio:active {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked.png"), url("assets/menuitem-radio-checked@2.png"));
+.menuitem.radio:active, .menuitem.radio:checked {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked.png"), url("assets/menuitem-radio-checked@2.png"));
 }
 
-.menuitem.radio:active:hover {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked-selected.png"), url("assets/menuitem-radio-checked-selected@2.png"));
+.menuitem.radio:active:hover, .menuitem.radio:checked:hover {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked-selected.png"), url("assets/menuitem-radio-checked-selected@2.png"));
 }
 
-.menuitem.radio:active:insensitive {
-    background-image: -gtk-scaled(url("assets/menuitem-radio-checked-insensitive.png"), url("assets/menuitem-radio-checked-insensitive@2.png"));
+.menuitem.radio:active:insensitive, .menuitem.radio:checked:insensitive {
+    -gtk-icon-source: -gtk-scaled(url("assets/menuitem-radio-checked-insensitive.png"), url("assets/menuitem-radio-checked-insensitive@2.png"));
 }
 
 /******************


### PR DESCRIPTION
This fixes theme in gtk3.14 (checkboxes and radio buttons are not displaying). Fix should be backward compatible (hopefully -gtk-icon-source can be used in older versions too), but I didn't test that.