### PR TITLE
[3.16] GTK 3.16 fixes

### DIFF
--- a/usr/share/themes/Mint-X-Aqua/gtk-3.0/apps/cinnamon-applications.css
+++ b/usr/share/themes/Mint-X-Aqua/gtk-3.0/apps/cinnamon-applications.css
@@ -29,6 +29,14 @@ NemoWindow .sidebar .expander:selected {
     color: @nemo_sidebar_selected_fg;
 }
 
+NemoWindow .overshoot {
+    background-color: alpha (@nemo_sidebar_selected_fg, 0.3);
+}
+
+NemoWindow .undershoot {
+	background-color: transparent;
+}
+
 NemoPlacesTreeView {
     -NemoPlacesTreeView-disk-full-bg-color: shade(@theme_base_color, 0.85);
     -NemoPlacesTreeView-disk-full-fg-color: shade(@theme_selected_bg_color, 0.9);

--- a/usr/share/themes/Mint-X-Aqua/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Aqua/gtk-3.0/gtk-widgets.css
@@ -1119,6 +1119,10 @@ GtkLevelBar.vertical {
     background-color: alpha (@theme_selected_bg_color, 0.3);
 }
 
+.undershoot {
+	background-color: transparent;
+}
+
 /********
  * menu *
  ********/

--- a/usr/share/themes/Mint-X-Aqua/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Aqua/gtk-3.0/gtk-widgets.css
@@ -1114,6 +1114,11 @@ GtkLevelBar.vertical {
     background-color: alpha(@theme_selected_bg_color, 0.3);
 }
 
+.overshoot,
+.sidebar.overshoot {
+    background-color: alpha (@theme_selected_bg_color, 0.3);
+}
+
 /********
  * menu *
  ********/
@@ -1522,8 +1527,8 @@ GtkOverlay.osd {
 
 GtkProgressBar {
     -GtkProgressBar-min-horizontal-bar-height: 16;
-	-GtkProgressBar-min-vertical-bar-width: 16;
-	padding: 0;
+    -GtkProgressBar-min-vertical-bar-width: 16;
+    padding: 0;
 }
 
 .progressbar,

--- a/usr/share/themes/Mint-X-Blue/gtk-3.0/apps/cinnamon-applications.css
+++ b/usr/share/themes/Mint-X-Blue/gtk-3.0/apps/cinnamon-applications.css
@@ -29,6 +29,14 @@ NemoWindow .sidebar .expander:selected {
     color: @nemo_sidebar_selected_fg;
 }
 
+NemoWindow .overshoot {
+    background-color: alpha (@nemo_sidebar_selected_fg, 0.3);
+}
+
+NemoWindow .undershoot {
+	background-color: transparent;
+}
+
 NemoPlacesTreeView {
     -NemoPlacesTreeView-disk-full-bg-color: shade(@theme_base_color, 0.85);
     -NemoPlacesTreeView-disk-full-fg-color: shade(@theme_selected_bg_color, 0.9);

--- a/usr/share/themes/Mint-X-Blue/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Blue/gtk-3.0/gtk-widgets.css
@@ -1119,6 +1119,10 @@ GtkLevelBar.vertical {
     background-color: alpha (@theme_selected_bg_color, 0.3);
 }
 
+.undershoot {
+	background-color: transparent;
+}
+
 /********
  * menu *
  ********/

--- a/usr/share/themes/Mint-X-Blue/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Blue/gtk-3.0/gtk-widgets.css
@@ -1114,6 +1114,11 @@ GtkLevelBar.vertical {
     background-color: alpha(@theme_selected_bg_color, 0.3);
 }
 
+.overshoot,
+.sidebar.overshoot {
+    background-color: alpha (@theme_selected_bg_color, 0.3);
+}
+
 /********
  * menu *
  ********/
@@ -1522,8 +1527,8 @@ GtkOverlay.osd {
 
 GtkProgressBar {
     -GtkProgressBar-min-horizontal-bar-height: 16;
-	-GtkProgressBar-min-vertical-bar-width: 16;
-	padding: 0;
+    -GtkProgressBar-min-vertical-bar-width: 16;
+    padding: 0;
 }
 
 .progressbar,

--- a/usr/share/themes/Mint-X-Brown/gtk-3.0/apps/cinnamon-applications.css
+++ b/usr/share/themes/Mint-X-Brown/gtk-3.0/apps/cinnamon-applications.css
@@ -29,6 +29,14 @@ NemoWindow .sidebar .expander:selected {
     color: @nemo_sidebar_selected_fg;
 }
 
+NemoWindow .overshoot {
+    background-color: alpha (@nemo_sidebar_selected_fg, 0.3);
+}
+
+NemoWindow .undershoot {
+	background-color: transparent;
+}
+
 NemoPlacesTreeView {
     -NemoPlacesTreeView-disk-full-bg-color: shade(@theme_base_color, 0.85);
     -NemoPlacesTreeView-disk-full-fg-color: shade(@theme_selected_bg_color, 0.9);

--- a/usr/share/themes/Mint-X-Brown/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Brown/gtk-3.0/gtk-widgets.css
@@ -1119,6 +1119,10 @@ GtkLevelBar.vertical {
     background-color: alpha (@theme_selected_bg_color, 0.3);
 }
 
+.undershoot {
+	background-color: transparent;
+}
+
 /********
  * menu *
  ********/

--- a/usr/share/themes/Mint-X-Brown/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Brown/gtk-3.0/gtk-widgets.css
@@ -1114,6 +1114,11 @@ GtkLevelBar.vertical {
     background-color: alpha(@theme_selected_bg_color, 0.3);
 }
 
+.overshoot,
+.sidebar.overshoot {
+    background-color: alpha (@theme_selected_bg_color, 0.3);
+}
+
 /********
  * menu *
  ********/
@@ -1522,8 +1527,8 @@ GtkOverlay.osd {
 
 GtkProgressBar {
     -GtkProgressBar-min-horizontal-bar-height: 16;
-	-GtkProgressBar-min-vertical-bar-width: 16;
-	padding: 0;
+    -GtkProgressBar-min-vertical-bar-width: 16;
+    padding: 0;
 }
 
 .progressbar,

--- a/usr/share/themes/Mint-X-Orange/gtk-3.0/apps/cinnamon-applications.css
+++ b/usr/share/themes/Mint-X-Orange/gtk-3.0/apps/cinnamon-applications.css
@@ -29,6 +29,14 @@ NemoWindow .sidebar .expander:selected {
     color: @nemo_sidebar_selected_fg;
 }
 
+NemoWindow .overshoot {
+    background-color: alpha (@nemo_sidebar_selected_fg, 0.3);
+}
+
+NemoWindow .undershoot {
+	background-color: transparent;
+}
+
 NemoPlacesTreeView {
     -NemoPlacesTreeView-disk-full-bg-color: shade(@theme_base_color, 0.85);
     -NemoPlacesTreeView-disk-full-fg-color: shade(@theme_selected_bg_color, 0.9);

--- a/usr/share/themes/Mint-X-Orange/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Orange/gtk-3.0/gtk-widgets.css
@@ -1119,6 +1119,10 @@ GtkLevelBar.vertical {
     background-color: alpha (@theme_selected_bg_color, 0.3);
 }
 
+.undershoot {
+	background-color: transparent;
+}
+
 /********
  * menu *
  ********/

--- a/usr/share/themes/Mint-X-Orange/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Orange/gtk-3.0/gtk-widgets.css
@@ -1114,6 +1114,11 @@ GtkLevelBar.vertical {
     background-color: alpha(@theme_selected_bg_color, 0.3);
 }
 
+.overshoot,
+.sidebar.overshoot {
+    background-color: alpha (@theme_selected_bg_color, 0.3);
+}
+
 /********
  * menu *
  ********/
@@ -1522,8 +1527,8 @@ GtkOverlay.osd {
 
 GtkProgressBar {
     -GtkProgressBar-min-horizontal-bar-height: 16;
-	-GtkProgressBar-min-vertical-bar-width: 16;
-	padding: 0;
+    -GtkProgressBar-min-vertical-bar-width: 16;
+    padding: 0;
 }
 
 .progressbar,

--- a/usr/share/themes/Mint-X-Pink/gtk-3.0/apps/cinnamon-applications.css
+++ b/usr/share/themes/Mint-X-Pink/gtk-3.0/apps/cinnamon-applications.css
@@ -29,6 +29,14 @@ NemoWindow .sidebar .expander:selected {
     color: @nemo_sidebar_selected_fg;
 }
 
+NemoWindow .overshoot {
+    background-color: alpha (@nemo_sidebar_selected_fg, 0.3);
+}
+
+NemoWindow .undershoot {
+	background-color: transparent;
+}
+
 NemoPlacesTreeView {
     -NemoPlacesTreeView-disk-full-bg-color: shade(@theme_base_color, 0.85);
     -NemoPlacesTreeView-disk-full-fg-color: shade(@theme_selected_bg_color, 0.9);

--- a/usr/share/themes/Mint-X-Pink/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Pink/gtk-3.0/gtk-widgets.css
@@ -1119,6 +1119,10 @@ GtkLevelBar.vertical {
     background-color: alpha (@theme_selected_bg_color, 0.3);
 }
 
+.undershoot {
+	background-color: transparent;
+}
+
 /********
  * menu *
  ********/

--- a/usr/share/themes/Mint-X-Pink/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Pink/gtk-3.0/gtk-widgets.css
@@ -1114,6 +1114,11 @@ GtkLevelBar.vertical {
     background-color: alpha(@theme_selected_bg_color, 0.3);
 }
 
+.overshoot,
+.sidebar.overshoot {
+    background-color: alpha (@theme_selected_bg_color, 0.3);
+}
+
 /********
  * menu *
  ********/
@@ -1522,8 +1527,8 @@ GtkOverlay.osd {
 
 GtkProgressBar {
     -GtkProgressBar-min-horizontal-bar-height: 16;
-	-GtkProgressBar-min-vertical-bar-width: 16;
-	padding: 0;
+    -GtkProgressBar-min-vertical-bar-width: 16;
+    padding: 0;
 }
 
 .progressbar,

--- a/usr/share/themes/Mint-X-Purple/gtk-3.0/apps/cinnamon-applications.css
+++ b/usr/share/themes/Mint-X-Purple/gtk-3.0/apps/cinnamon-applications.css
@@ -29,6 +29,14 @@ NemoWindow .sidebar .expander:selected {
     color: @nemo_sidebar_selected_fg;
 }
 
+NemoWindow .overshoot {
+    background-color: alpha (@nemo_sidebar_selected_fg, 0.3);
+}
+
+NemoWindow .undershoot {
+	background-color: transparent;
+}
+
 NemoPlacesTreeView {
     -NemoPlacesTreeView-disk-full-bg-color: shade(@theme_base_color, 0.85);
     -NemoPlacesTreeView-disk-full-fg-color: shade(@theme_selected_bg_color, 0.9);

--- a/usr/share/themes/Mint-X-Purple/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Purple/gtk-3.0/gtk-widgets.css
@@ -1119,6 +1119,10 @@ GtkLevelBar.vertical {
     background-color: alpha (@theme_selected_bg_color, 0.3);
 }
 
+.undershoot {
+	background-color: transparent;
+}
+
 /********
  * menu *
  ********/

--- a/usr/share/themes/Mint-X-Purple/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Purple/gtk-3.0/gtk-widgets.css
@@ -1114,6 +1114,11 @@ GtkLevelBar.vertical {
     background-color: alpha(@theme_selected_bg_color, 0.3);
 }
 
+.overshoot,
+.sidebar.overshoot {
+    background-color: alpha (@theme_selected_bg_color, 0.3);
+}
+
 /********
  * menu *
  ********/
@@ -1522,8 +1527,8 @@ GtkOverlay.osd {
 
 GtkProgressBar {
     -GtkProgressBar-min-horizontal-bar-height: 16;
-	-GtkProgressBar-min-vertical-bar-width: 16;
-	padding: 0;
+    -GtkProgressBar-min-vertical-bar-width: 16;
+    padding: 0;
 }
 
 .progressbar,

--- a/usr/share/themes/Mint-X-Red/gtk-3.0/apps/cinnamon-applications.css
+++ b/usr/share/themes/Mint-X-Red/gtk-3.0/apps/cinnamon-applications.css
@@ -29,6 +29,14 @@ NemoWindow .sidebar .expander:selected {
     color: @nemo_sidebar_selected_fg;
 }
 
+NemoWindow .overshoot {
+    background-color: alpha (@nemo_sidebar_selected_fg, 0.3);
+}
+
+NemoWindow .undershoot {
+	background-color: transparent;
+}
+
 NemoPlacesTreeView {
     -NemoPlacesTreeView-disk-full-bg-color: shade(@theme_base_color, 0.85);
     -NemoPlacesTreeView-disk-full-fg-color: shade(@theme_selected_bg_color, 0.9);

--- a/usr/share/themes/Mint-X-Red/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Red/gtk-3.0/gtk-widgets.css
@@ -1119,6 +1119,10 @@ GtkLevelBar.vertical {
     background-color: alpha (@theme_selected_bg_color, 0.3);
 }
 
+.undershoot {
+	background-color: transparent;
+}
+
 /********
  * menu *
  ********/

--- a/usr/share/themes/Mint-X-Red/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Red/gtk-3.0/gtk-widgets.css
@@ -1114,6 +1114,11 @@ GtkLevelBar.vertical {
     background-color: alpha(@theme_selected_bg_color, 0.3);
 }
 
+.overshoot,
+.sidebar.overshoot {
+    background-color: alpha (@theme_selected_bg_color, 0.3);
+}
+
 /********
  * menu *
  ********/
@@ -1522,8 +1527,8 @@ GtkOverlay.osd {
 
 GtkProgressBar {
     -GtkProgressBar-min-horizontal-bar-height: 16;
-	-GtkProgressBar-min-vertical-bar-width: 16;
-	padding: 0;
+    -GtkProgressBar-min-vertical-bar-width: 16;
+    padding: 0;
 }
 
 .progressbar,

--- a/usr/share/themes/Mint-X-Sand/gtk-3.0/apps/cinnamon-applications.css
+++ b/usr/share/themes/Mint-X-Sand/gtk-3.0/apps/cinnamon-applications.css
@@ -29,6 +29,14 @@ NemoWindow .sidebar .expander:selected {
     color: @nemo_sidebar_selected_fg;
 }
 
+NemoWindow .overshoot {
+    background-color: alpha (@nemo_sidebar_selected_fg, 0.3);
+}
+
+NemoWindow .undershoot {
+	background-color: transparent;
+}
+
 NemoPlacesTreeView {
     -NemoPlacesTreeView-disk-full-bg-color: shade(@theme_base_color, 0.85);
     -NemoPlacesTreeView-disk-full-fg-color: shade(@theme_selected_bg_color, 0.9);

--- a/usr/share/themes/Mint-X-Sand/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Sand/gtk-3.0/gtk-widgets.css
@@ -1119,6 +1119,10 @@ GtkLevelBar.vertical {
     background-color: alpha (@theme_selected_bg_color, 0.3);
 }
 
+.undershoot {
+	background-color: transparent;
+}
+
 /********
  * menu *
  ********/

--- a/usr/share/themes/Mint-X-Sand/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Sand/gtk-3.0/gtk-widgets.css
@@ -1114,6 +1114,11 @@ GtkLevelBar.vertical {
     background-color: alpha(@theme_selected_bg_color, 0.3);
 }
 
+.overshoot,
+.sidebar.overshoot {
+    background-color: alpha (@theme_selected_bg_color, 0.3);
+}
+
 /********
  * menu *
  ********/
@@ -1522,8 +1527,8 @@ GtkOverlay.osd {
 
 GtkProgressBar {
     -GtkProgressBar-min-horizontal-bar-height: 16;
-	-GtkProgressBar-min-vertical-bar-width: 16;
-	padding: 0;
+    -GtkProgressBar-min-vertical-bar-width: 16;
+    padding: 0;
 }
 
 .progressbar,

--- a/usr/share/themes/Mint-X-Teal/gtk-3.0/apps/cinnamon-applications.css
+++ b/usr/share/themes/Mint-X-Teal/gtk-3.0/apps/cinnamon-applications.css
@@ -29,6 +29,14 @@ NemoWindow .sidebar .expander:selected {
     color: @nemo_sidebar_selected_fg;
 }
 
+NemoWindow .overshoot {
+    background-color: alpha (@nemo_sidebar_selected_fg, 0.3);
+}
+
+NemoWindow .undershoot {
+	background-color: transparent;
+}
+
 NemoPlacesTreeView {
     -NemoPlacesTreeView-disk-full-bg-color: shade(@theme_base_color, 0.85);
     -NemoPlacesTreeView-disk-full-fg-color: shade(@theme_selected_bg_color, 0.9);

--- a/usr/share/themes/Mint-X-Teal/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Teal/gtk-3.0/gtk-widgets.css
@@ -1119,6 +1119,10 @@ GtkLevelBar.vertical {
     background-color: alpha (@theme_selected_bg_color, 0.3);
 }
 
+.undershoot {
+	background-color: transparent;
+}
+
 /********
  * menu *
  ********/

--- a/usr/share/themes/Mint-X-Teal/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Teal/gtk-3.0/gtk-widgets.css
@@ -1114,6 +1114,11 @@ GtkLevelBar.vertical {
     background-color: alpha(@theme_selected_bg_color, 0.3);
 }
 
+.overshoot,
+.sidebar.overshoot {
+    background-color: alpha (@theme_selected_bg_color, 0.3);
+}
+
 /********
  * menu *
  ********/
@@ -1522,8 +1527,8 @@ GtkOverlay.osd {
 
 GtkProgressBar {
     -GtkProgressBar-min-horizontal-bar-height: 16;
-	-GtkProgressBar-min-vertical-bar-width: 16;
-	padding: 0;
+    -GtkProgressBar-min-vertical-bar-width: 16;
+    padding: 0;
 }
 
 .progressbar,

--- a/usr/share/themes/Mint-X/gtk-3.0/apps/cinnamon-applications.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/apps/cinnamon-applications.css
@@ -29,6 +29,14 @@ NemoWindow .sidebar .expander:selected {
     color: @nemo_sidebar_selected_fg;
 }
 
+NemoWindow .overshoot {
+    background-color: alpha (@nemo_sidebar_selected_fg, 0.3);
+}
+
+NemoWindow .undershoot {
+	background-color: transparent;
+}
+
 NemoPlacesTreeView {
     -NemoPlacesTreeView-disk-full-bg-color: shade(@theme_base_color, 0.85);
     -NemoPlacesTreeView-disk-full-fg-color: shade(@theme_selected_bg_color, 0.9);

--- a/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
@@ -1119,6 +1119,10 @@ GtkLevelBar.vertical {
     background-color: alpha (@theme_selected_bg_color, 0.3);
 }
 
+.undershoot {
+	background-color: transparent;
+}
+
 /********
  * menu *
  ********/

--- a/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
@@ -1114,6 +1114,11 @@ GtkLevelBar.vertical {
     background-color: alpha(@theme_selected_bg_color, 0.3);
 }
 
+.overshoot,
+.sidebar.overshoot {
+    background-color: alpha (@theme_selected_bg_color, 0.3);
+}
+
 /********
  * menu *
  ********/
@@ -1522,8 +1527,8 @@ GtkOverlay.osd {
 
 GtkProgressBar {
     -GtkProgressBar-min-horizontal-bar-height: 16;
-	-GtkProgressBar-min-vertical-bar-width: 16;
-	padding: 0;
+    -GtkProgressBar-min-vertical-bar-width: 16;
+    padding: 0;
 }
 
 .progressbar,


### PR DESCRIPTION
GTK 3.16, which is now available in Debian ~~Testing~~ Experimental, required some fixes for the the theme to display correctly. I don't have any experience with writing GTK themes, but I seemed to fix the display issues by adding overscroll and underscroll classes ( a new feature introduced in 3.16).

Overscroll is activated when you scroll with the mouse wheel to the end of an element - it's similar to what one would find scrolling on a mobile device. Underscroll is sort of the opposite, I don't know how it's supposed to work, but it caused white bars to show up in Nemo's sidebar until I explicitly disabled it (set it to transparent).
