### PR TITLE
treeview-entries: Fix the size of entries in treeviews

### DIFF
--- a/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
@@ -542,6 +542,10 @@ GtkDrawingArea {
     color: @theme_text_color;
 }
 
+GtkTreeView.view .entry {
+    padding: 0;
+}
+
 .entry.image.left {
     padding-right: 6px;
 }
@@ -2173,11 +2177,6 @@ GtkTreeView.dnd {
 }
 
 GtkTreeView:selected:focus {
-}
-
-GtkTreeView .entry {
-    border-color: @theme_fg_color;
-    border-width: 1px;
 }
 
 GtkTreeView row:nth-child(even),


### PR DESCRIPTION
Fixes huge entries when renaming files in the Nemo list view or Dconf view