### PR TITLE
Add some additional theming for client-side-decorated windows

### DIFF
--- a/usr/share/themes/Mint-X-Aqua/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Aqua/gtk-3.0/gtk-widgets.css
@@ -531,6 +531,17 @@ GdMainIconView.content-view {
     box-shadow: 0 2px 3px alpha(black, 0.3);
 }
 
+.window-frame.solid-csd {
+    border-radius: 0;
+    margin: 1px;
+    background-color: @theme_bg_color;
+    box-shadow: none;
+}
+
+.solid-csd .header-bar.titlebar {
+    border-radius: 0;
+}
+
 /****************
  * drawing area *
  ****************/

--- a/usr/share/themes/Mint-X-Blue/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Blue/gtk-3.0/gtk-widgets.css
@@ -531,6 +531,17 @@ GdMainIconView.content-view {
     box-shadow: 0 2px 3px alpha(black, 0.3);
 }
 
+.window-frame.solid-csd {
+    border-radius: 0;
+    margin: 1px;
+    background-color: @theme_bg_color;
+    box-shadow: none;
+}
+
+.solid-csd .header-bar.titlebar {
+    border-radius: 0;
+}
+
 /****************
  * drawing area *
  ****************/

--- a/usr/share/themes/Mint-X-Brown/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Brown/gtk-3.0/gtk-widgets.css
@@ -531,6 +531,17 @@ GdMainIconView.content-view {
     box-shadow: 0 2px 3px alpha(black, 0.3);
 }
 
+.window-frame.solid-csd {
+    border-radius: 0;
+    margin: 1px;
+    background-color: @theme_bg_color;
+    box-shadow: none;
+}
+
+.solid-csd .header-bar.titlebar {
+    border-radius: 0;
+}
+
 /****************
  * drawing area *
  ****************/

--- a/usr/share/themes/Mint-X-Grey/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Grey/gtk-3.0/gtk-widgets.css
@@ -531,6 +531,17 @@ GdMainIconView.content-view {
     box-shadow: 0 2px 3px alpha(black, 0.3);
 }
 
+.window-frame.solid-csd {
+    border-radius: 0;
+    margin: 1px;
+    background-color: @theme_bg_color;
+    box-shadow: none;
+}
+
+.solid-csd .header-bar.titlebar {
+    border-radius: 0;
+}
+
 /****************
  * drawing area *
  ****************/

--- a/usr/share/themes/Mint-X-Orange/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Orange/gtk-3.0/gtk-widgets.css
@@ -531,6 +531,17 @@ GdMainIconView.content-view {
     box-shadow: 0 2px 3px alpha(black, 0.3);
 }
 
+.window-frame.solid-csd {
+    border-radius: 0;
+    margin: 1px;
+    background-color: @theme_bg_color;
+    box-shadow: none;
+}
+
+.solid-csd .header-bar.titlebar {
+    border-radius: 0;
+}
+
 /****************
  * drawing area *
  ****************/

--- a/usr/share/themes/Mint-X-Pink/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Pink/gtk-3.0/gtk-widgets.css
@@ -531,6 +531,17 @@ GdMainIconView.content-view {
     box-shadow: 0 2px 3px alpha(black, 0.3);
 }
 
+.window-frame.solid-csd {
+    border-radius: 0;
+    margin: 1px;
+    background-color: @theme_bg_color;
+    box-shadow: none;
+}
+
+.solid-csd .header-bar.titlebar {
+    border-radius: 0;
+}
+
 /****************
  * drawing area *
  ****************/

--- a/usr/share/themes/Mint-X-Purple/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Purple/gtk-3.0/gtk-widgets.css
@@ -531,6 +531,17 @@ GdMainIconView.content-view {
     box-shadow: 0 2px 3px alpha(black, 0.3);
 }
 
+.window-frame.solid-csd {
+    border-radius: 0;
+    margin: 1px;
+    background-color: @theme_bg_color;
+    box-shadow: none;
+}
+
+.solid-csd .header-bar.titlebar {
+    border-radius: 0;
+}
+
 /****************
  * drawing area *
  ****************/

--- a/usr/share/themes/Mint-X-Red/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Red/gtk-3.0/gtk-widgets.css
@@ -531,6 +531,17 @@ GdMainIconView.content-view {
     box-shadow: 0 2px 3px alpha(black, 0.3);
 }
 
+.window-frame.solid-csd {
+    border-radius: 0;
+    margin: 1px;
+    background-color: @theme_bg_color;
+    box-shadow: none;
+}
+
+.solid-csd .header-bar.titlebar {
+    border-radius: 0;
+}
+
 /****************
  * drawing area *
  ****************/

--- a/usr/share/themes/Mint-X-Sand/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Sand/gtk-3.0/gtk-widgets.css
@@ -531,6 +531,17 @@ GdMainIconView.content-view {
     box-shadow: 0 2px 3px alpha(black, 0.3);
 }
 
+.window-frame.solid-csd {
+    border-radius: 0;
+    margin: 1px;
+    background-color: @theme_bg_color;
+    box-shadow: none;
+}
+
+.solid-csd .header-bar.titlebar {
+    border-radius: 0;
+}
+
 /****************
  * drawing area *
  ****************/

--- a/usr/share/themes/Mint-X-Teal/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X-Teal/gtk-3.0/gtk-widgets.css
@@ -531,6 +531,17 @@ GdMainIconView.content-view {
     box-shadow: 0 2px 3px alpha(black, 0.3);
 }
 
+.window-frame.solid-csd {
+    border-radius: 0;
+    margin: 1px;
+    background-color: @theme_bg_color;
+    box-shadow: none;
+}
+
+.solid-csd .header-bar.titlebar {
+    border-radius: 0;
+}
+
 /****************
  * drawing area *
  ****************/

--- a/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
+++ b/usr/share/themes/Mint-X/gtk-3.0/gtk-widgets.css
@@ -531,6 +531,17 @@ GdMainIconView.content-view {
     box-shadow: 0 2px 3px alpha(black, 0.3);
 }
 
+.window-frame.solid-csd {
+    border-radius: 0;
+    margin: 1px;
+    background-color: @theme_bg_color;
+    box-shadow: none;
+}
+
+.solid-csd .header-bar.titlebar {
+    border-radius: 0;
+}
+
 /****************
  * drawing area *
  ****************/


### PR DESCRIPTION
This fixes an issue when using Marco without compositing in Mate where csd windows such as Calculator get a large black border drawn around them.